### PR TITLE
Allow access to host's /tmp and /var/tmp

### DIFF
--- a/org.vim.Vim.json
+++ b/org.vim.Vim.json
@@ -15,6 +15,8 @@
   ],
   "finish-args": [
     "--filesystem=host",
+    "--filesystem=/tmp",
+    "--filesystem=/var/tmp",
     "--share=ipc",
     "--socket=x11",
     "--socket=wayland"


### PR DESCRIPTION
This is needed for `EDITOR=org.vim.Vim sudoedit` to work properly (as
discussed in https://github.com/flathub/org.vim.Vim/issues/2).