### PR TITLE
Update to v8.1.0255

### DIFF
--- a/org.vim.Vim.appdata.xml
+++ b/org.vim.Vim.appdata.xml
@@ -25,8 +25,10 @@ SentUpstream: 2014-05-22
     </p>
   </description>
   <releases>
-    <release version="v8.0.1433" date="2018-01-29">
-      <description>Initial Flathub release of most recent available version.</description>
+    <release version="v8.1.0255" date="2018-08-08">
+      <description>
+        <p>The main new feature of Vim 8.1 is support for running a terminal in a Vim window. A few new features have been added since Vim 8.0. A lot of bugs have been fixed, documentation was updated, etc.</p>
+      </description>
     </release>
   </releases>
   <screenshots>

--- a/org.vim.Vim.json
+++ b/org.vim.Vim.json
@@ -62,8 +62,8 @@
         {
           "type": "git",
           "url": "https://github.com/vim/vim",
-          "tag": "v8.0.1433",
-          "commit": "95dbcbea6d85a5b79d9617ab3863458fdf0217a0"
+          "tag": "v8.1.0255",
+          "commit": "f8f88f89e12df516c1fac5851b504238ebc1d2d4"
         },
         {
           "type": "file",


### PR DESCRIPTION
`appstreamcli validate org.vim.Vim.appdata.xml` fails with:

```
E - org.vim.Vim.appdata.xml:~:7
    The metainfo file uses an ancient version of the AppStream specification, which 
    can not be validated. Please migrate it to version 0.6 (or higher).

Validation failed: errors: 1
```

but it worked before in practice so I assume it will continue to work.