### PR TITLE
Build ctags

### DIFF
--- a/ctags.yaml
+++ b/ctags.yaml
@@ -1,0 +1,6 @@
+name: ctags
+sources:
+  - type: git
+    url: https://github.com/universal-ctags/ctags
+    # No releases! Nice.
+    commit: 42b74d5dbe70dc315e650fb4d2b5acaa19db114e

--- a/org.vim.Vim.json
+++ b/org.vim.Vim.json
@@ -24,6 +24,7 @@
   ],
   "modules": [
     "shared-modules/lua5.3/lua-5.3.2.json",
+    "ctags.yaml",
     {
       "name": "vim",
       "build-options": {


### PR DESCRIPTION
Vim has native support for reading the databases generated by this
tool. This adds 1MB to the app but I think it's worth it.

`cscope` would also be nice but it fails to link due to missing `erasechar` symbol and I haven't got the time or patience for this.