### PR TITLE
Use flatpak-external-data-check for updates

### DIFF
--- a/org.vim.Vim.appdata.xml
+++ b/org.vim.Vim.appdata.xml
@@ -24,7 +24,7 @@ SentUpstream: 2014-05-22
     </p>
   </description>
   <releases>
-    <release version="v8.2.2072" date="2020-11-30">
+    <release version="8.2.2072" date="2020-11-30">
       <description>
         <p>The latest upstream commit.</p>
       </description>

--- a/org.vim.Vim.json
+++ b/org.vim.Vim.json
@@ -68,7 +68,14 @@
           "type": "git",
           "url": "https://github.com/vim/vim",
           "tag": "v8.2.2072",
-          "commit": "004d9b00ba600a167746ad7af88e0baa77c95d8f"
+          "commit": "004d9b00ba600a167746ad7af88e0baa77c95d8f",
+          "x-checker-data": {
+            "type": "json",
+            "url": "https://api.github.com/repos/vim/vim/tags",
+            "tag-query": "first | .name",
+            "version-query": "$tag | sub(\"^[vV]\"; \"\")",
+            "commit-query": "first | .commit.sha"
+          }
         },
         {
           "type": "file",


### PR DESCRIPTION
flatpak-external-data-check now supports git and we can use JSONChecker to query GitHub API for tags.