### PR TITLE
Don't expose Wayland socket

### DIFF
--- a/org.vim.Vim.json
+++ b/org.vim.Vim.json
@@ -19,7 +19,6 @@
     "--share=ipc",
     "--share=network",
     "--socket=x11",
-    "--socket=wayland",
     "--talk-name=org.freedesktop.Flatpak"
   ],
   "modules": [


### PR DESCRIPTION
On Flathub it is now an error to use --socket=x11 + --socket=wayland
without --socket=fallback-x11.

Sadly, (g)Vim does not have native Wayland support. So, don't expose the
Wayland socket to Vim.

https://github.com/vim/vim/issues/4727
https://github.com/vim/vim/pull/9639
